### PR TITLE
chore: describe `config` command in a readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,22 +11,12 @@ This MCP server provides Claude with access to Vuetify component information, la
 - Providing information about Vuetify features
 - Answering questions about the Vuetify framework
 
-## Installation
-
-```bash
-# Install dependencies
-pnpm install
-
-# Start the server
-pnpm bootstrap
-```
-
 ## Quick Start
 
 Run Vuetify MCP with a single command:
 
 ```bash
-npx -y @vuetify/mcp --api-key=YOUR_API_KEY
+npx -y @vuetify/mcp
 ```
 
 ## Configuration for Claude
@@ -36,7 +26,7 @@ npx -y @vuetify/mcp --api-key=YOUR_API_KEY
 Quickly set up the config using our CLI:
 
 ```bash
-npx -y @vuetify/mcp config --api-key=YOUR_API_KEY
+npx -y @vuetify/mcp config
 ```
 
 ### Manual Configuration
@@ -52,15 +42,10 @@ To use this MCP server with Claude, add the following to your `.vscode/mcp.json`
         "-y",
         "@vuetify/mcp"
       ],
-      "env": {
-        "VUETIFY_API_KEY": "your_api_key_here"
-      }
     }
   }
 }
 ```
-
-Make sure to replace `/absolute/path/to` with the actual absolute path to the `vuetify-mcp` directory.
 
 Additionally, ensure that automatic discovery is enabled in your `settings.json` file:
 
@@ -109,6 +94,15 @@ vuetify-mcp/
 ```
 
 ## Development
+
+
+```bash
+# Install dependencies
+pnpm install
+
+# Run development server
+pnpm dev
+```
 
 To add new features or extend existing ones:
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ npx -y @vuetify/mcp --api-key=YOUR_API_KEY
 
 ## Configuration for Claude
 
+### Automatic Discovery
+
+Get ready to use with a single command:
+
+```bash
+npx -y @vuetify/mcp config --api-key=YOUR_API_KEY
+```
+
+### Manual Configuration
+
 To use this MCP server with Claude, add the following to your `.vscode/mcp.json` file (or move it to `settings.json` for global usage):
 
 ```json

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npx -y @vuetify/mcp --api-key=YOUR_API_KEY
 
 ### Automatic Discovery
 
-Get ready to use with a single command:
+Quickly set up the config using our CLI:
 
 ```bash
 npx -y @vuetify/mcp config --api-key=YOUR_API_KEY


### PR DESCRIPTION
> [!NOTE]  
Merge before the next release to avoid user's confusion

After #3 was merged, user will be able to run a command with `npx @vuetify/mcp config`, so this PR updates README to mention that