### PR TITLE
fix: findFileRecursive doesn't handle access errors

### DIFF
--- a/src/cli/detect/index.ts
+++ b/src/cli/detect/index.ts
@@ -66,7 +66,12 @@ function findFileRecursive (startPath: string, filter: string) {
 
   let results = [] as string[]
 
-  const files = fs.readdirSync(startPath)
+  let files = [] as string[]
+  try {
+    files = fs.readdirSync(startPath)
+  } catch {
+    return []
+  }
   for (const file of files) {
     const filename = path.join(startPath, file)
     let stat


### PR DESCRIPTION
fixes #8 

Just adding try/catch for `fs.readDirSync` since there are cases when it can throw, and should probably just let the rest of things continue on and skip the problematic directory.