### PR TITLE
fix(http): parse --key=value CLI flags so the container binds its port

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,14 +25,43 @@ function parseArgs () {
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i]
-    if (arg === '--transport' && i + 1 < args.length) {
-      transport = args[++i]
-    } else if (arg === '--port' && i + 1 < args.length) {
-      port = Number.parseInt(args[++i], 10)
-    } else if (arg === '--host' && i + 1 < args.length) {
-      host = args[++i]
-    } else if (arg === '--path' && i + 1 < args.length) {
-      path = args[++i]
+    const eq = arg.indexOf('=')
+    const inline = arg.startsWith('--') && eq !== -1
+    const key = inline ? arg.slice(0, eq) : arg
+    const value = inline ? arg.slice(eq + 1) : args[i + 1]
+
+    if (value === undefined) {
+      continue
+    }
+
+    switch (key) {
+      case '--transport': {
+        transport = value
+
+        break
+      }
+      case '--port': {
+        port = Number.parseInt(value, 10)
+
+        break
+      }
+      case '--host': {
+        host = value
+
+        break
+      }
+      case '--path': {
+        path = value
+
+        break
+      }
+      default: {
+        continue
+      }
+    }
+
+    if (!inline) {
+      i++
     }
   }
 


### PR DESCRIPTION
## Problem

`mcp.vuetifyjs.com` has been returning **502 on every request** and the container kept restarting with nothing useful in the logs.

## Root cause

PR #22 (`refactor: delegate CLI to @vuetify/mcp-cli via npx`) replaced `bin/cli.js` with a pure pass-through and dropped `citty`. `citty` had been silently normalizing the Dockerfile `CMD`'s `=`-joined flags (`--transport=http`) into the space-separated form (`--transport http`) before invoking `dist/index.js`.

The Dockerfile `CMD` was **not** changed, but `index.ts:parseArgs()` only ever matched the space form (`arg === '--transport'`). So the deployed container silently fell back to the default **`stdio`** transport, never bound port 3000, and crash-looped:

- nothing listening on :3000 → Coolify/Cloudflare → constant **502**
- stdio process exits on stdin EOF → PID 1 exits → Coolify restarts → "keeps restarting"
- no exception/stack and no HTTP "listening" line → **logs reveal nothing**
- the deploy went green because the **build** is fine — it's a pure runtime arg mismatch

## Fix

Make `parseArgs()` accept both `--key=value` and `--key value`.

## Verification

Ran the literal Docker entrypoint against the built code:

```
node bin/cli.js --transport=http --host=127.0.0.1 --port=3071 --path=/mcp
# → "MCP Server listening on http://127.0.0.1:3071/mcp"
# GET /health → 200 {"status":"ok"}
# GET /        → 200 info page
```

Before the fix, the same invocation parsed `transport: 'stdio'` and bound nothing.