### PR TITLE
docs(vuetify0): align composable inventory with v0 v1

### DIFF
--- a/src/services/vuetify0.ts
+++ b/src/services/vuetify0.ts
@@ -20,8 +20,6 @@ export const VUETIFY0_COMPOSABLES = {
     name: 'Registration',
     description: 'Manage collections and registries',
     composables: {
-      createModel: 'Value store layer extending createRegistry with a reactive Set of selected IDs and useProxyModel sync',
-      createNested: 'Manage nested/hierarchical context structures with parent-child relationships',
       createQueue: 'Registry queue management',
       createRegistry: 'Foundation for registration-based systems with automatic indexing',
       createTimeline: 'Bounded undo/redo system with fixed-size history',
@@ -32,10 +30,12 @@ export const VUETIFY0_COMPOSABLES = {
     name: 'Selection',
     description: 'Manage selection state in collections',
     composables: {
+      createModel: 'Value store layer extending createRegistry with a reactive Set of selected IDs and useProxyModel sync',
       createSelection: 'Creates a selection instance for managing multiple selected items (factory function)',
       createGroup: 'Creates a group instance with batch selection operations (extends createSelection)',
       createSingle: 'Creates a single-selection instance (enforces only one selected item)',
       createStep: 'Creates a step/stepper instance for managing multi-step processes',
+      createNested: 'Manage nested/hierarchical context structures with parent-child relationships',
     },
   },
   forms: {
@@ -51,15 +51,12 @@ export const VUETIFY0_COMPOSABLES = {
       createRating: 'Rating state management with hover preview and half-star support',
       createSlider: 'Slider state management: value math, step snapping, percentage conversion, and multi-thumb support',
       createValidation: 'Per-input validation built on createGroup',
-      useRules: 'Validation rule composable with Standard Schema support',
     },
   },
   system: {
     name: 'System',
     description: 'DOM observers and event handlers with automatic cleanup',
     composables: {
-      createFocusTraversal: 'Internal factory for useRovingFocus and useVirtualFocus focus traversal patterns',
-      createObserver: 'Internal factory for observer composables (IntersectionObserver, MutationObserver, ResizeObserver)',
       useClickOutside: 'Detect clicks outside an element',
       useDelay: 'Schedule open and close transitions with start, stop, pause, and resume controls and a reactive view of the pending delay.',
       useDragDrop: 'Headless drag-and-drop primitive. Owns two registries — draggables and zones — plus the active-drag state.',
@@ -67,6 +64,7 @@ export const VUETIFY0_COMPOSABLES = {
       useHotkey: 'Keyboard hotkey/shortcut handling',
       useImage: 'Tracks image loading state as a reactive state machine with idle, loading, loaded, and error states.',
       useIntersectionObserver: 'Detect element visibility changes',
+      useLazy: 'Deferred/lazy evaluation of expensive computations',
       useMediaQuery: 'Reactive CSS media query matching',
       useMutationObserver: 'Observe DOM mutations',
       usePopover: 'Native popover API behavior with CSS anchor positioning',
@@ -87,12 +85,12 @@ export const VUETIFY0_COMPOSABLES = {
       useDate: 'Date utilities and formatting',
       useFeatures: 'Feature flag management',
       useHydration: 'SSR hydration utilities',
-      useLazy: 'Deferred/lazy evaluation of expensive computations',
       useLocale: 'Internationalization support',
       useLogger: 'Logging system',
       useNotifications: 'Notification management built on createRegistry and createQueue',
       usePermissions: 'Permission management',
-      useReducedMotion: "Respect or override the user's `prefers-reduced-motion` setting, with a reactive flag and a body data attribute for CSS-only consumers.",
+      useReducedMotion: 'Respect or override the user\'s `prefers-reduced-motion` setting, with a reactive flag and a body data attribute for CSS-only consumers.',
+      useRules: 'Validation rule composable with Standard Schema support',
       useRtl: 'RTL (right-to-left) direction detection with adapter pattern',
       useStack: 'Stack-based state management for layered contexts (dialogs, menus, etc.)',
       useStorage: 'Storage abstraction (localStorage/sessionStorage)',
@@ -104,16 +102,22 @@ export const VUETIFY0_COMPOSABLES = {
     name: 'Data',
     description: 'Data processing, filtering, pagination, and virtualization',
     composables: {
-      createBreadcrumbs: 'Breadcrumb navigation built on createSingle',
       createDataGrid: 'A headless data grid with column layout, cell editing, row ordering, and row spanning.',
       createDataTable: 'Composable data table that composes existing v0 primitives (selection, pagination, sorting, filtering)',
       createFilter: 'Filter arrays based on search queries',
       createKanban: 'Two-level board state for columns of cards, with column reorder, in-column reorder, and a cross-column `transfer` primitive.',
-      createOverflow: 'Computes how many items fit in a container based on available width',
       createPagination: 'Lightweight pagination for navigating through pages with next/prev/first/last methods',
-      createProgress: 'Progress state management for determinate and indeterminate indicators',
       createSortable: 'Ordered-list state with `move`, `swap`, and `reorder` mutations.',
       createVirtual: 'Virtual scrolling for efficiently rendering large lists',
+    },
+  },
+  semantic: {
+    name: 'Semantic',
+    description: 'Navigation and content-structure primitives',
+    composables: {
+      createBreadcrumbs: 'Breadcrumb navigation built on createSingle',
+      createOverflow: 'Computes how many items fit in a container based on available width',
+      createProgress: 'Progress state management for determinate and indeterminate indicators',
     },
   },
   reactivity: {
@@ -387,7 +391,7 @@ export function createVuetify0Service () {
         })
         .join('\n\n')
 
-      return text(`# @vuetify/v0 Composables\n\nVuetify0 provides 71 tree-shakeable composables organized into 9 categories:\n\n${categories}\n\n**Note**: Vuetify0 is currently in pre-release. Features may not function as expected.\n\n**Documentation**: https://0.vuetifyjs.com/composables`)
+      return text(`# @vuetify/v0 Composables\n\nVuetify0 provides 71 tree-shakeable composables organized into 10 categories:\n\n${categories}\n\n**Note**: Vuetify0 is currently in pre-release. Features may not function as expected.\n\n**Documentation**: https://0.vuetifyjs.com/composables`)
     },
 
     getComponentList: async () => {


### PR DESCRIPTION
## Summary

v0 v1 is out. Reconciles the MCP's hardcoded `VUETIFY0_COMPOSABLES` inventory (`src/services/vuetify0.ts`) against the `@vuetify/v0` source of truth (composable barrels + `maturity.json`). Surfaced by the `/mirror` audit.

`origin/master` was already synced on counts (71/40), `AspectRatio`, all shipped composables, and had zero draft-component leakage. The remaining drift was entirely in the composable inventory:

### Removed — internal factories, not public exports
- `createFocusTraversal` — backs `useRovingFocus`/`useVirtualFocus`
- `createObserver` — backs the `use*Observer` composables

These are not barrel exports; publishing them as public composables was a genuine bug (present in the live server too).

### Category placement fixed to match v0
| Composable | Was | Now |
|---|---|---|
| createModel | registration | selection |
| createNested | registration | selection |
| createBreadcrumbs | data | **semantic** (new) |
| createOverflow | data | **semantic** (new) |
| createProgress | data | **semantic** (new) |
| useRules | forms | plugins |
| useLazy | plugins | system |

`semantic` is a new category (v0 has 10 composable categories; the MCP had 9). Category keys feed the docs URL in `getComposableGuide`, so this keeps deep-links valid.

### Count string
`getComposableList` now says "71 composables across 10 categories" (was 9). Composable total stays 71 after removing the 2 factories.

## Verification
- `npx tsc --noEmit` clean
- Script-verified: 71 composables across 10 categories, both factories gone

Components and subpath exports already matched v0 v1 — no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)