### PR TITLE
ci: pin npm@11 in release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
       - uses: vuetifyjs/setup-action@master
       - run: pnpm build
-      - run: npm install -g npm@latest
+      - run: npm install -g npm@11
       - run: npm publish
       - run: pnpm conventional-github-releaser -p vuetify
         env:


### PR DESCRIPTION
## Summary

The `v0.8.0` release tag pushed but **nothing published to npm** — the CI `release` job failed at `npm install -g npm@latest`.

Root cause: `npm@latest` is now `12.0.1`, which requires node `>=22.22.2`, but `vuetifyjs/setup-action@master` pins node `22.15.0`. The step exits 1 *before* `npm publish` runs.

## Fix

Pin `npm@11` — still `>=11.5.1` (required for OIDC trusted publishing, which this workflow uses via `id-token: write`) and compatible with node 22.15.0.

## After merge

`v0.8.0` still needs to be published. Two options:
- Move the `v0.8.0` tag to the commit that includes this fix and re-push (nothing published against it yet, no GH release exists), or
- cut `v0.8.1`.

Note: the CLI release workflow has the same `npm install -g npm@latest` line but survived because it uses `actions/setup-node@lts/*` (resolved to a newer node). Latent fragility worth pinning there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)