### PR TITLE
fix(docker): pin pnpm 10.24.0 via corepack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,10 @@ WORKDIR /app
 # Copy package files
 COPY package*.json pnpm-lock.yaml ./
 
-# Install pnpm and dependencies
-RUN npm install -g pnpm && pnpm install --frozen-lockfile
+# Pin to packageManager (10.24.0). Unpinned `npm i -g pnpm` then fails
+# --frozen-lockfile on a linux-x64 optional binary this lockfile omits.
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+RUN corepack enable && corepack prepare pnpm@10.24.0 --activate && pnpm install --frozen-lockfile
 
 # Copy source
 COPY . .


### PR DESCRIPTION
Coolify builds were installing latest pnpm globally, then `pnpm install --frozen-lockfile` failed because that pnpm looks for a linux-x64 optional binary this lockfile does not record.

Activate `pnpm@10.24.0` (the `packageManager` field) through corepack instead.