### PR TITLE
feat: add directory-review annotations and Origin checks

### DIFF
--- a/src/tools/api.ts
+++ b/src/tools/api.ts
@@ -75,6 +75,10 @@ export async function registerApiTools (server: McpServer) {
     {
       version: z.string().default('latest').describe('The version of Vuetify to retrieve API types for, e.g., "latest" or "3.0.0"'),
     },
+    {
+      title: 'Get Vuetify API by version',
+      readOnlyHint: true,
+    },
     async ({ version }) => {
       await cacheApi(version)
 
@@ -95,6 +99,10 @@ export async function registerApiTools (server: McpServer) {
     {
       componentName: z.string().describe('The name of a Vuetify component, available options here: https://vuetifyjs.com/components/all/'),
       version: z.string().default('latest').describe('The version of Vuetify to retrieve API types for, e.g., "latest" or "3.0.0"'),
+    },
+    {
+      title: 'Get component API by version',
+      readOnlyHint: true,
     },
     async ({ componentName, version }) => {
       const api: VuetifyWebTypes = JSON.parse(await cacheApi(version))
@@ -130,6 +138,10 @@ export async function registerApiTools (server: McpServer) {
     {
       directiveName: z.string().describe('The name of a Vuetify directive, e.g., "v-ripple" or "ripple"'),
       version: z.string().default('latest').describe('The version of Vuetify to retrieve API types for, e.g., "latest" or "3.0.0"'),
+    },
+    {
+      title: 'Get directive API by version',
+      readOnlyHint: true,
     },
     async ({ directiveName, version }) => {
       const api: VuetifyWebTypes = JSON.parse(await cacheApi(version))

--- a/src/tools/documentation.ts
+++ b/src/tools/documentation.ts
@@ -29,12 +29,20 @@ export async function registerDocumentationTools (server: McpServer) {
       ssr: z.boolean().default(false).describe('Whether to return the SSR version of the installation guide.'),
       fresh: z.boolean().default(false).describe('Whether the user has an existing project or is starting fresh.'),
     },
+    {
+      title: 'Get installation guide',
+      readOnlyHint: true,
+    },
     documentation.getInstallationGuide,
   )
 
   server.tool(
     'get_feature_guides',
     'Get a list of available features in the documentation.',
+    {
+      title: 'Get feature guides',
+      readOnlyHint: true,
+    },
     documentation.getFeatureGuides,
   )
 
@@ -44,18 +52,30 @@ export async function registerDocumentationTools (server: McpServer) {
     {
       feature: z.enum(features).describe(`The feature for which to get the documentation. Available features: ${features.join(', ')}`),
     },
+    {
+      title: 'Get feature guide',
+      readOnlyHint: true,
+    },
     documentation.getFeatureGuide,
   )
 
   server.tool(
     'get_exposed_exports',
     'Get a list of exports from the Vuetify npm package',
+    {
+      title: 'Get exposed exports',
+      readOnlyHint: true,
+    },
     documentation.getExposedExports,
   )
 
   server.tool(
     'get_frequently_asked_questions',
     'Get a list of frequently asked questions about Vuetify.',
+    {
+      title: 'Get frequently asked questions',
+      readOnlyHint: true,
+    },
     documentation.getFrequentlyAskedQuestions,
   )
 
@@ -65,12 +85,20 @@ export async function registerDocumentationTools (server: McpServer) {
     {
       version: z.string().describe('One or more Vuetify versions for which to get the release notes.').default('latest'),
     },
+    {
+      title: 'Get release notes by version',
+      readOnlyHint: true,
+    },
     documentation.getReleaseNotesByVersion,
   )
 
   server.tool(
     'get_vuetify_one_installation_guide',
     'Get the README contents for @vuetify/one package from GitHub, including installation and usage instructions.',
+    {
+      title: 'Get Vuetify One installation guide',
+      readOnlyHint: true,
+    },
     documentation.getVuetifyOneInstallationGuide,
   )
 
@@ -81,6 +109,10 @@ export async function registerDocumentationTools (server: McpServer) {
     {
       version: z.enum(upgradeVersions).describe(`The source Vuetify version to upgrade from. Available versions: ${upgradeVersions.join(', ')}`),
     },
+    {
+      title: 'Get upgrade guide',
+      readOnlyHint: true,
+    },
     documentation.getUpgradeGuide,
   )
 
@@ -90,6 +122,10 @@ export async function registerDocumentationTools (server: McpServer) {
     {
       category: z.enum(breakingChangeCategories).optional().describe(`Optional category to filter by. Available categories: ${breakingChangeCategories.join(', ')}. Omit to get all breaking changes.`),
     },
+    {
+      title: 'Get Vuetify 4 breaking changes',
+      readOnlyHint: true,
+    },
     documentation.getV4BreakingChanges,
   )
 
@@ -97,24 +133,40 @@ export async function registerDocumentationTools (server: McpServer) {
   server.tool(
     'get_vuetify0_installation_guide',
     'Get the README contents for @vuetify/v0 (Vuetify0) package from GitHub, including installation and usage instructions for this headless meta-framework.',
+    {
+      title: 'Get Vuetify0 installation guide',
+      readOnlyHint: true,
+    },
     vuetify0.getInstallationGuide,
   )
 
   server.tool(
     'get_vuetify0_package_guide',
     'Get the package-specific documentation for @vuetify/v0 from GitHub.',
+    {
+      title: 'Get Vuetify0 package guide',
+      readOnlyHint: true,
+    },
     vuetify0.getPackageGuide,
   )
 
   server.tool(
     'get_vuetify0_composable_list',
     'Get a comprehensive list of all 71 composables available in @vuetify/v0, organized by category (foundation, registration, selection, forms, system, plugins, data, reactivity, transformers).',
+    {
+      title: 'Get Vuetify0 composable list',
+      readOnlyHint: true,
+    },
     vuetify0.getComposableList,
   )
 
   server.tool(
     'get_vuetify0_component_list',
     'Get a list of all 40 headless components available in @vuetify/v0.',
+    {
+      title: 'Get Vuetify0 component list',
+      readOnlyHint: true,
+    },
     vuetify0.getComponentList,
   )
 
@@ -128,6 +180,10 @@ export async function registerDocumentationTools (server: McpServer) {
       category: z.enum(categories).describe(`The category of the composable. Available categories: ${categories.join(', ')}`),
       name: z.string().describe('The name of the composable (e.g., "createContext", "useSelection", "useTheme")'),
     },
+    {
+      title: 'Get Vuetify0 composable guide',
+      readOnlyHint: true,
+    },
     vuetify0.getComposableGuide,
   )
 
@@ -137,18 +193,30 @@ export async function registerDocumentationTools (server: McpServer) {
     {
       name: z.enum(components).describe(`The name of the component. Available components: ${components.join(', ')}`),
     },
+    {
+      title: 'Get Vuetify0 component guide',
+      readOnlyHint: true,
+    },
     vuetify0.getComponentGuide,
   )
 
   server.tool(
     'get_vuetify0_exports_list',
     'Get a list of all subpath exports available in @vuetify/v0 (utilities, types, constants, date, data-table, palettes, theme, locale, logger, and more).',
+    {
+      title: 'Get Vuetify0 exports list',
+      readOnlyHint: true,
+    },
     vuetify0.getExportsList,
   )
 
   server.tool(
     'get_vuetify0_skill',
     'Get the latest SKILL.md reference for @vuetify/v0 — a compact guide with patterns, anti-patterns, and common mistakes optimized for AI coding assistants.',
+    {
+      title: 'Get Vuetify0 skill',
+      readOnlyHint: true,
+    },
     vuetify0.getSkill,
   )
 }

--- a/src/tools/issues.ts
+++ b/src/tools/issues.ts
@@ -27,6 +27,10 @@ export function registerIssuesTools (server: McpServer) {
       repo: z.enum(REPO_SLUGS).describe(`The repository to report a bug against. Available: ${REPO_SLUGS.join(', ')}`),
       label: z.string().optional().describe('Optional label to pre-fill on the bug report.'),
     },
+    {
+      title: 'Create bug report',
+      readOnlyHint: true,
+    },
     ({ repo, label }) => {
       const params = new URLSearchParams({ repo, type: 'bug' })
 

--- a/src/tools/one/bin.ts
+++ b/src/tools/one/bin.ts
@@ -34,6 +34,8 @@ export async function registerBinTools (server: McpServer) {
       locked: z.boolean().default(false),
     },
     {
+      title: 'Create Vuetify bin',
+      destructiveHint: true,
       openWorldHint: true,
     },
     async (bin, extra) => {
@@ -82,6 +84,8 @@ export async function registerBinTools (server: McpServer) {
     'Get all user bins.',
     {},
     {
+      title: 'Get all bins',
+      readOnlyHint: true,
       openWorldHint: true,
     },
     async (_args, extra) => {
@@ -150,6 +154,8 @@ export async function registerBinTools (server: McpServer) {
       locked: z.boolean().optional(),
     },
     {
+      title: 'Update Vuetify bin',
+      destructiveHint: true,
       openWorldHint: true,
     },
     async ({ id, ...bin }, extra) => {
@@ -206,6 +212,8 @@ export async function registerBinTools (server: McpServer) {
       id: z.string(),
     },
     {
+      title: 'Get bin',
+      readOnlyHint: true,
       openWorldHint: true,
     },
     async ({ id }, extra) => {

--- a/src/tools/one/link.ts
+++ b/src/tools/one/link.ts
@@ -36,6 +36,8 @@ export async function registerLinkTools (server: McpServer) {
       scoped: z.boolean().default(false).describe('When true, the slug is unique to your account; when false, the slug is reserved globally.'),
     },
     {
+      title: 'Create Vuetify link',
+      destructiveHint: true,
       openWorldHint: true,
     },
     async (link, extra) => {
@@ -85,6 +87,8 @@ export async function registerLinkTools (server: McpServer) {
     'Get all user links.',
     {},
     {
+      title: 'Get all links',
+      readOnlyHint: true,
       openWorldHint: true,
     },
     async (_args, extra) => {

--- a/src/tools/one/playground.ts
+++ b/src/tools/one/playground.ts
@@ -64,6 +64,8 @@ export async function registerPlaygroundTools (server: McpServer) {
       locked: z.boolean().default(false),
     },
     {
+      title: 'Create Vuetify playground',
+      destructiveHint: true,
       openWorldHint: true,
     },
     async (playground, extra) => {
@@ -113,6 +115,8 @@ export async function registerPlaygroundTools (server: McpServer) {
     'Get all user playgrounds.',
     {},
     {
+      title: 'Get all playgrounds',
+      readOnlyHint: true,
       openWorldHint: true,
     },
     async (_args, extra) => {
@@ -179,6 +183,8 @@ export async function registerPlaygroundTools (server: McpServer) {
       locked: z.boolean().optional(),
     },
     {
+      title: 'Update Vuetify playground',
+      destructiveHint: true,
       openWorldHint: true,
     },
     async ({ id, ...playground }, extra) => {
@@ -235,6 +241,8 @@ export async function registerPlaygroundTools (server: McpServer) {
       id: z.string().describe('The playground ID'),
     },
     {
+      title: 'Get playground',
+      readOnlyHint: true,
       openWorldHint: true,
     },
     async ({ id }, extra) => {

--- a/src/transports/http.spec.ts
+++ b/src/transports/http.spec.ts
@@ -2,6 +2,7 @@ import type { AddressInfo } from 'node:net'
 import type { Server } from 'node:http'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { startHttpServer } from './http.js'
+import { ONE_TOOL_NAMES } from '#tools/one/names'
 
 const headers = {
   Accept: 'application/json, text/event-stream',
@@ -17,6 +18,59 @@ function originUrl (server: Server): string {
   const address = server.address() as AddressInfo
   return `http://127.0.0.1:${address.port}`
 }
+
+async function mcpJson (response: Response): Promise<any> {
+  const text = await response.text()
+  const ctype = response.headers.get('content-type') ?? ''
+  if (ctype.includes('text/event-stream')) {
+    const line = text.split('\n').find(l => l.startsWith('data: '))
+    if (!line) throw new Error(`no SSE data: ${text}`)
+    return JSON.parse(line.slice(6))
+  }
+  return JSON.parse(text)
+}
+
+const MUTATING_ONE_TOOLS = [
+  'create_vuetify_bin',
+  'update_vuetify_bin',
+  'create_vuetify_link',
+  'create_vuetify_playground',
+  'update_vuetify_playground',
+] as const
+
+const READ_ONE_TOOLS = [
+  'get_all_bins',
+  'get_bin',
+  'get_all_links',
+  'get_all_playgrounds',
+  'get_playground',
+] as const
+
+const EXPECTED_TOOLS = [
+  'get_vuetify_api_by_version',
+  'get_component_api_by_version',
+  'get_directive_api_by_version',
+  'get_installation_guide',
+  'get_feature_guides',
+  'get_feature_guide',
+  'get_exposed_exports',
+  'get_frequently_asked_questions',
+  'get_release_notes_by_version',
+  'get_vuetify_one_installation_guide',
+  'get_upgrade_guide',
+  'get_v4_breaking_changes',
+  'get_vuetify0_installation_guide',
+  'get_vuetify0_package_guide',
+  'get_vuetify0_composable_list',
+  'get_vuetify0_component_list',
+  'get_vuetify0_composable_guide',
+  'get_vuetify0_component_guide',
+  'get_vuetify0_exports_list',
+  'get_vuetify0_skill',
+  'create_bug_report',
+  ...MUTATING_ONE_TOOLS,
+  ...READ_ONE_TOOLS,
+] as const
 
 describe('http oauth gate', () => {
   let server: Server
@@ -65,35 +119,40 @@ describe('http oauth gate', () => {
   })
 
   it('returns 401 with WWW-Authenticate for unauthenticated One tools/call', async () => {
-    const response = await fetch(mcpUrl(server), {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({
-        jsonrpc: '2.0',
-        id: 3,
-        method: 'tools/call',
-        params: { name: 'create_vuetify_bin', arguments: {} },
-      }),
-    })
+    for (const name of ONE_TOOL_NAMES) {
+      const response = await fetch(mcpUrl(server), {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 3,
+          method: 'tools/call',
+          params: { name, arguments: {} },
+        }),
+      })
 
-    expect(response.status).toBe(401)
-    expect(response.headers.get('www-authenticate')).toContain('resource_metadata')
-    expect(await response.json()).toEqual({ error: 'unauthorized' })
+      expect(response.status, name).toBe(401)
+      expect(response.headers.get('www-authenticate')).toContain('resource_metadata')
+      expect(await response.json()).toEqual({ error: 'unauthorized' })
+    }
   })
 
   it('does not 401 unauthenticated public docs tools/call', async () => {
-    const response = await fetch(mcpUrl(server), {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({
-        jsonrpc: '2.0',
-        id: 3,
-        method: 'tools/call',
-        params: { name: 'get_vuetify0_composable_list', arguments: {} },
-      }),
-    })
+    for (const name of ['get_vuetify0_composable_list', 'get_installation_guide', 'create_bug_report'] as const) {
+      const response = await fetch(mcpUrl(server), {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 3,
+          method: 'tools/call',
+          params: { name, arguments: {} },
+        }),
+      })
 
-    expect(response.status).not.toBe(401)
+      expect(response.status, name).not.toBe(401)
+      expect(response.status, name).not.toBe(403)
+    }
   })
 
   it('advertises RFC9728 resource with /mcp', async () => {
@@ -123,6 +182,246 @@ describe('http oauth gate', () => {
     } finally {
       if (prev === undefined) delete process.env.MCP_SERVER_URL
       else process.env.MCP_SERVER_URL = prev
+    }
+  })
+})
+
+describe('http origin validation', () => {
+  let server: Server
+
+  beforeAll(async () => {
+    server = await startHttpServer({ host: '127.0.0.1', port: 0 })
+  })
+
+  afterAll(() => {
+    return new Promise<void>((resolve, reject) => {
+      server.close(error => error ? reject(error) : resolve())
+    })
+  })
+
+  function listBody () {
+    return JSON.stringify({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/list',
+      params: {},
+    })
+  }
+
+  it('does not 403 initialize or tools/list when Origin is missing', async () => {
+    const url = mcpUrl(server)
+
+    const initialize = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'test', version: '0.0.0' },
+        },
+      }),
+    })
+
+    const list = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: listBody(),
+    })
+
+    expect(initialize.status).not.toBe(403)
+    expect(list.status).not.toBe(403)
+    expect(initialize.headers.get('access-control-allow-origin')).toBeNull()
+    expect(list.headers.get('access-control-allow-origin')).toBeNull()
+  })
+
+  it('returns 403 for an invalid Origin', async () => {
+    const response = await fetch(mcpUrl(server), {
+      method: 'POST',
+      headers: { ...headers, Origin: 'https://evil.example.com' },
+      body: listBody(),
+    })
+
+    expect(response.status).toBe(403)
+  })
+
+  it('returns 403 for an empty Origin', async () => {
+    const response = await fetch(mcpUrl(server), {
+      method: 'POST',
+      headers: { ...headers, Origin: '' },
+      body: listBody(),
+    })
+
+    expect(response.status).toBe(403)
+  })
+
+  it('allows https://claude.ai', async () => {
+    const response = await fetch(mcpUrl(server), {
+      method: 'POST',
+      headers: { ...headers, Origin: 'https://claude.ai' },
+      body: listBody(),
+    })
+
+    expect(response.status).not.toBe(403)
+  })
+
+  it('allows http://127.0.0.1 with the listen port', async () => {
+    const local = originUrl(server)
+    const response = await fetch(mcpUrl(server), {
+      method: 'POST',
+      headers: { ...headers, Origin: local },
+      body: listBody(),
+    })
+
+    expect(response.status).not.toBe(403)
+  })
+
+  it('allows the default resource origin', async () => {
+    const prev = process.env.MCP_SERVER_URL
+    delete process.env.MCP_SERVER_URL
+    try {
+      const response = await fetch(mcpUrl(server), {
+        method: 'POST',
+        headers: { ...headers, Origin: 'https://mcp.vuetifyjs.com' },
+        body: listBody(),
+      })
+
+      expect(response.status).not.toBe(403)
+    } finally {
+      if (prev === undefined) delete process.env.MCP_SERVER_URL
+      else process.env.MCP_SERVER_URL = prev
+    }
+  })
+
+  it('reflects an allowed Origin on MCP POST and does not use *', async () => {
+    const response = await fetch(mcpUrl(server), {
+      method: 'POST',
+      headers: { ...headers, Origin: 'https://claude.ai' },
+      body: listBody(),
+    })
+
+    expect(response.headers.get('access-control-allow-origin')).toBe('https://claude.ai')
+    expect(response.headers.get('access-control-allow-origin')).not.toBe('*')
+  })
+
+  it('returns 403 for an invalid Origin on One tools/call before 401', async () => {
+    const response = await fetch(mcpUrl(server), {
+      method: 'POST',
+      headers: { ...headers, Origin: 'https://evil.example.com' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: { name: 'create_vuetify_bin', arguments: {} },
+      }),
+    })
+
+    expect(response.status).toBe(403)
+    expect(response.headers.get('www-authenticate')).toBeNull()
+  })
+
+  it('reflects an allowed Origin on OPTIONS and 403s an invalid one', async () => {
+    const allowed = await fetch(mcpUrl(server), {
+      method: 'OPTIONS',
+      headers: { Origin: 'https://claude.ai' },
+    })
+    expect(allowed.status).toBe(204)
+    expect(allowed.headers.get('access-control-allow-origin')).toBe('https://claude.ai')
+    expect(allowed.headers.get('access-control-allow-origin')).not.toBe('*')
+
+    const denied = await fetch(mcpUrl(server), {
+      method: 'OPTIONS',
+      headers: { Origin: 'https://evil.example.com' },
+    })
+    expect(denied.status).toBe(403)
+  })
+
+  it('reflects an allowed Origin on 401 One tools/call', async () => {
+    const response = await fetch(mcpUrl(server), {
+      method: 'POST',
+      headers: { ...headers, Origin: 'https://claude.ai' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: { name: 'create_vuetify_bin', arguments: {} },
+      }),
+    })
+
+    expect(response.status).toBe(401)
+    expect(response.headers.get('access-control-allow-origin')).toBe('https://claude.ai')
+  })
+})
+
+describe('http tool annotations', () => {
+  let server: Server
+
+  beforeAll(async () => {
+    server = await startHttpServer({ host: '127.0.0.1', port: 0 })
+  })
+
+  afterAll(() => {
+    return new Promise<void>((resolve, reject) => {
+      server.close(error => error ? reject(error) : resolve())
+    })
+  })
+
+  it('lists every tool with title and exactly one of readOnly/destructive', async () => {
+    const response = await fetch(mcpUrl(server), {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/list',
+        params: {},
+      }),
+    })
+
+    expect(response.status).not.toBe(401)
+    expect(response.status).not.toBe(403)
+
+    const body = await mcpJson(response)
+    const tools = body.result?.tools as Array<{
+      name: string
+      annotations?: {
+        title?: string
+        readOnlyHint?: boolean
+        destructiveHint?: boolean
+      }
+    }>
+
+    expect(Array.isArray(tools)).toBe(true)
+    expect(tools.length).toBeGreaterThan(0)
+
+    const names = tools.map(tool => tool.name)
+    expect([...names].sort()).toEqual([...EXPECTED_TOOLS].sort())
+    expect([...MUTATING_ONE_TOOLS, ...READ_ONE_TOOLS].sort()).toEqual([...ONE_TOOL_NAMES].sort())
+
+    for (const tool of tools) {
+      expect(tool.name.length).toBeLessThanOrEqual(64)
+      expect(typeof tool.annotations?.title).toBe('string')
+      expect(tool.annotations?.title?.length).toBeGreaterThan(0)
+
+      const readOnly = tool.annotations?.readOnlyHint === true
+      const destructive = tool.annotations?.destructiveHint === true
+      expect(readOnly !== destructive).toBe(true)
+
+      if ((MUTATING_ONE_TOOLS as readonly string[]).includes(tool.name)) {
+        expect(tool.annotations?.destructiveHint).toBe(true)
+        expect(tool.annotations?.readOnlyHint).not.toBe(true)
+      } else {
+        expect(tool.annotations?.readOnlyHint).toBe(true)
+        expect(tool.annotations?.destructiveHint).not.toBe(true)
+      }
+    }
+
+    for (const name of READ_ONE_TOOLS) {
+      const tool = tools.find(item => item.name === name)
+      expect(tool?.annotations?.readOnlyHint).toBe(true)
     }
   })
 })

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -18,6 +18,7 @@ import { setApiKey, withToolLogging } from '#services/logger'
 import packageJson from '../../package.json' with { type: 'json' }
 import { RateLimiter } from '../utils/rate-limiter.js'
 import type { RateLimiterOptions } from '../utils/rate-limiter.js'
+import { getRequestOrigin, isAllowedOrigin } from './origin.js'
 
 export interface HttpServerOptions {
   port?: number
@@ -101,10 +102,19 @@ function getResourceUrl (): string {
   return getServerUrl()
 }
 
-function sendJson (res: ServerResponse, body: unknown) {
+function applyCors (res: ServerResponse, origin: string | undefined): void {
+  if (!origin) {
+    return
+  }
+
+  res.setHeader('Access-Control-Allow-Origin', origin)
+  res.setHeader('Vary', 'Origin')
+}
+
+function sendJson (res: ServerResponse, body: unknown, origin?: string) {
+  applyCors(res, origin)
   res.writeHead(200, {
     'Content-Type': 'application/json',
-    'Access-Control-Allow-Origin': '*',
     'Cache-Control': 'max-age=3600',
   })
   res.end(JSON.stringify(body))
@@ -119,6 +129,8 @@ function handleOauthRoutes (req: IncomingMessage, res: ServerResponse): boolean 
     return false
   }
 
+  const origin = getRequestOrigin(req)
+
   // RFC 9728 — OAuth 2.0 Protected Resource Metadata
   if (req.url.startsWith('/.well-known/oauth-protected-resource')) {
     sendJson(res, {
@@ -126,7 +138,7 @@ function handleOauthRoutes (req: IncomingMessage, res: ServerResponse): boolean 
       authorization_servers: [getApiUrl()],
       scopes_supported: ['mcp'],
       bearer_methods_supported: ['header'],
-    })
+    }, origin)
     return true
   }
 
@@ -149,7 +161,7 @@ function handleOauthRoutes (req: IncomingMessage, res: ServerResponse): boolean 
       authorization_response_iss_parameter_supported: true,
       client_id_metadata_document_supported: true,
       protected_resources: [getResourceUrl()],
-    })
+    }, origin)
     return true
   }
 
@@ -173,10 +185,17 @@ async function handleRequest (
 ): Promise<void> {
   console.error(`[${new Date().toISOString()}] ${req.method} ${req.url}`)
 
+  const origin = getRequestOrigin(req)
+  if (origin !== undefined && !isAllowedOrigin(origin, getResourceUrl())) {
+    res.writeHead(403, { 'Content-Type': 'text/plain' })
+    res.end('Forbidden')
+    return
+  }
+
   // Handle CORS preflight
   if (req.method === 'OPTIONS') {
+    applyCors(res, origin)
     res.writeHead(204, {
-      'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
       'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-Vuetify-Api-Key',
     })
@@ -270,6 +289,7 @@ async function handleMcpPost (
 
   const token = extractAuthToken(req)
   if (!token && hasOneToolCall(body)) {
+    applyCors(res, getRequestOrigin(req))
     res.writeHead(401, {
       'Content-Type': 'application/json',
       'WWW-Authenticate': `Bearer resource_metadata="${new URL(getServerUrl()).origin}/.well-known/oauth-protected-resource"`,
@@ -310,6 +330,9 @@ async function handleMcpPost (
   transport.onclose = () => {
     server.close().catch(error => console.error('Error closing server:', error))
   }
+
+  // setHeader before writeHead so Node merges ACAO with the SDK response
+  applyCors(res, getRequestOrigin(req))
 
   // Handle the request
   await transport.handleRequest(req, res, body)

--- a/src/transports/origin.spec.ts
+++ b/src/transports/origin.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { getRequestOrigin, isAllowedOrigin } from './origin.js'
+
+const resource = 'https://mcp.vuetifyjs.com/mcp'
+
+describe('isAllowedOrigin', () => {
+  it('allows localhost with a port over http or https', () => {
+    expect(isAllowedOrigin('http://localhost:5173', resource)).toBe(true)
+    expect(isAllowedOrigin('https://127.0.0.1:8443', resource)).toBe(true)
+    expect(isAllowedOrigin('http://[::1]:3000', resource)).toBe(true)
+  })
+
+  it('rejects an evil origin', () => {
+    expect(isAllowedOrigin('https://evil.example.com', resource)).toBe(false)
+  })
+
+  it('skips resource-origin matching when the resource URL cannot be parsed', () => {
+    expect(isAllowedOrigin('https://mcp.vuetifyjs.com', 'not a url')).toBe(false)
+    expect(isAllowedOrigin('https://claude.ai', '%%%')).toBe(true)
+  })
+
+  it('rejects an empty origin string', () => {
+    expect(isAllowedOrigin('', resource)).toBe(false)
+  })
+})
+
+describe('getRequestOrigin', () => {
+  it('treats a missing header as absent', () => {
+    expect(getRequestOrigin({ headers: {} } as any)).toBeUndefined()
+  })
+
+  it('treats multiple Origin headers as an empty present value', () => {
+    expect(getRequestOrigin({ headers: { origin: ['https://claude.ai', 'https://evil.example.com'] } } as any)).toBe('')
+  })
+})

--- a/src/transports/origin.ts
+++ b/src/transports/origin.ts
@@ -1,0 +1,59 @@
+/**
+ * Origin header checks for browser clients.
+ *
+ * Missing Origin is allowed (Claude/Cursor backends, Inspector). Empty string is present and invalid.
+ */
+import type { IncomingMessage } from 'node:http'
+
+const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]'])
+
+const EXTRA_ORIGINS = new Set([
+  'https://claude.ai',
+  'https://www.claude.ai',
+  'https://claude.com',
+  'https://www.claude.com',
+  'https://www.cursor.com',
+  'https://cursor.com',
+])
+
+export function getRequestOrigin (req: IncomingMessage): string | undefined {
+  const origin = req.headers.origin
+  // Multiple Origin headers are not spec; treat as present and invalid.
+  if (Array.isArray(origin)) {
+    return ''
+  }
+
+  if (typeof origin !== 'string') {
+    return undefined
+  }
+
+  return origin
+}
+
+export function isAllowedOrigin (origin: string, resourceUrl: string): boolean {
+  let parsed: URL
+  try {
+    parsed = new URL(origin)
+  } catch {
+    return false
+  }
+
+  const normalized = parsed.origin
+
+  if (EXTRA_ORIGINS.has(normalized)) {
+    return true
+  }
+
+  if (
+    (parsed.protocol === 'http:' || parsed.protocol === 'https:')
+    && LOCAL_HOSTS.has(parsed.hostname)
+  ) {
+    return true
+  }
+
+  try {
+    return normalized === new URL(resourceUrl).origin
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
Closes the two Anthropic connector directory-review gaps without changing split-auth.

- Every `server.tool` now has `annotations.title` plus `readOnlyHint` (docs/api/issues/vuetify0 and One reads) or `destructiveHint` (One mutating tools). Names are unchanged.
- HTTP Origin is allowed when missing (Claude/Cursor backends, Inspector). Present + invalid is 403. Allowed origins: resource origin from `MCP_SERVER_URL`, localhost/127.0.0.1, `https://claude.ai`, `https://cursor.com` / `https://www.cursor.com`.
- CORS reflects an allowed Origin on MCP POST/OPTIONS instead of `*`.
- Public `get_vuetify0_*` and other docs tools stay unauthenticated. One `tools/call` is still 401 + `WWW-Authenticate` without a Bearer.
- Dockerfile CMD stays `--path=/mcp`.