### PR TITLE
feat: add Cursor Agent Plugin package (plugin.json + mcp.json)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ npx -y @vuetify/mcp
 
 This command downloads and runs the latest version of the Vuetify MCP server, making it immediately available to your MCP-compatible clients.
 
+## Cursor / Agent Plugin
+
+This repo is an [Agent Plugins](https://agent-plugins.org/) 1.0.0 package (`plugin.json` + `mcp.json`) that points compatible clients at the hosted server.
+
+- Hosted MCP: https://mcp.vuetifyjs.com/mcp
+- Privacy: https://vuetifyjs.com/en/legal/mcp-privacy
+
+Local test: copy or symlink this repo to `~/.cursor/plugins/local/vuetify-mcp`.
+
 ## Configuration
 
 You can configure the Vuetify MCP server in your IDE or client by running the interactive CLI or by manually updating your settings file.

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "vuetify-mcp": {
+      "type": "streamable-http",
+      "url": "https://mcp.vuetifyjs.com/mcp"
+    }
+  }
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "vuetify-mcp",
+  "version": "1.0.0",
+  "description": "Official hosted Vuetify MCP: docs, APIs, bins, playgrounds, vtfy.link. Privacy: https://vuetifyjs.com/en/legal/mcp-privacy",
+  "author": {
+    "name": "Vuetify LLC",
+    "email": "hello@vuetifyjs.com",
+    "url": "https://vuetifyjs.com"
+  },
+  "homepage": "https://0.vuetifyjs.com/guide/tooling/vuetify-mcp",
+  "repository": "https://github.com/vuetifyjs/mcp",
+  "license": "MIT",
+  "keywords": ["vuetify", "mcp", "vue", "documentation"]
+}


### PR DESCRIPTION
Add a root Agent Plugins 1.0.0 package so Cursor and other compatible clients can load this repo as a plugin that points at the hosted Vuetify MCP.

- `plugin.json` — closed 1.0.0 schema, name `vuetify-mcp`
- `mcp.json` — `streamable-http` to https://mcp.vuetifyjs.com/mcp
- README — hosted URL, privacy policy, local test via `~/.cursor/plugins/local/vuetify-mcp`

Does not submit to the Cursor marketplace and does not change the npm package.